### PR TITLE
Fix MapWidget env variables

### DIFF
--- a/src/components/widgets/MapWidget.tsx
+++ b/src/components/widgets/MapWidget.tsx
@@ -21,8 +21,8 @@ interface ZoomButtonProps {
 export function MapWidget() {
   const mapStyle = "chinmaykunkikar/clc3j5l73005k14mpx2ghpj5x";
   const mapStyleUri = `mapbox://styles/${mapStyle}`;
-  const longitude = process.env.NEXT_PUBLIC_MAP_LONGITUDE;
-  const latitude = process.env.NEXT_PUBLIC_MAP_LATITUDE;
+  const longitude = parseFloat(process.env.NEXT_PUBLIC_MAP_LONGITUDE ?? "0");
+  const latitude = parseFloat(process.env.NEXT_PUBLIC_MAP_LATITUDE ?? "0");
 
   const defaultZoom = 13;
   const minZoom = 3.65;
@@ -153,14 +153,14 @@ export function MapWidget() {
         disabled={currentZoomIndex <= minZoomIndex}
         position="right-4"
       >
-        <PlusIcon width={16} height={16} strokeWidth={3} />
+        <MinusIcon width={16} height={16} strokeWidth={3} />
       </ZoomButton>
       <ZoomButton
         action="zoomIn"
         disabled={currentZoomIndex >= maxZoomIndex}
         position="right-16"
       >
-        <MinusIcon width={16} height={16} strokeWidth={3} />
+        <PlusIcon width={16} height={16} strokeWidth={3} />
       </ZoomButton>
       <div className="pointer-events-none absolute flex h-full w-full items-center justify-center">
         <div className="relative z-20 h-12 w-12 rotate-12 opacity-90 transition-transform group-hover:rotate-0 group-hover:scale-125 group-hover:opacity-100 md:h-16 md:w-16">

--- a/src/types/environment.d.ts
+++ b/src/types/environment.d.ts
@@ -7,8 +7,8 @@ declare global {
       SPOTIFY_CLIENT_SECRET: string;
       SPOTIFY_REFRESH_TOKEN: string;
       NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN: string;
-      NEXT_PUBLIC_MAP_LONGITUDE: float;
-      NEXT_PUBLIC_MAP_LATITUDE: float;
+      NEXT_PUBLIC_MAP_LONGITUDE: number;
+      NEXT_PUBLIC_MAP_LATITUDE: number;
       GITHUB_READ_USER_TOKEN_PERSONAL: string;
       NEXT_PUBLIC_STATSY_SITE_ID: string;
       NEXT_PUBLIC_STATSY_ENDPOINT: string;


### PR DESCRIPTION
## Summary
- fix numeric env var types
- parse numeric env vars before passing to Mapbox
- swap zoom button icons

## Testing
- `npx tsc src/types/environment.d.ts src/components/widgets/MapWidget.tsx --noEmit` *(fails: Cannot find module and other TS errors)*
- `npm run lint` *(interactive setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6846b179f4388329ba09888a31b4901e